### PR TITLE
Fix output and preserve mdl exit code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM ruby
-
 RUN gem install mdl
-
 COPY . .
-
 RUN chmod +x /entrypoint.sh
-
-ENTRYPOINT ["bash", "/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,16 @@
+#!/bin/bash
+
 output=$(mdl $INPUT_PATH)
-echo ::set-output name=output::"$output"
-if [ ! -z "$output" ]
-then
-    echo "FOUND MARKDOWN ISSUS"
-    exit 255
+exit_code=$?
+
+echo "$output"
+
+# See https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
+output="${output//'%'/'%25'}"
+output="${output//$'\n'/'%0A'}"
+output="${output//$'\r'/'%0D'}" 
+echo "::set-output name=output::$output"
+
+if [[ $exit_code != 0 ]]; then
+    exit $exit_code
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,4 @@ output="${output//$'\n'/'%0A'}"
 output="${output//$'\r'/'%0D'}" 
 echo "::set-output name=output::$output"
 
-if [[ $exit_code != 0 ]]; then
-    exit $exit_code
-fi
+exit $exit_code


### PR DESCRIPTION
# Description

The captured GitHub Action output was not usable - see https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870.
Additionally the exit code from mdl was set to 255 - now the original exit code is preserved.