### PR TITLE
build: reduce ruby docker image size bloat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby
+FROM ruby:alpine
 RUN gem install mdl
 COPY . .
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
# Description

The default `ruby` docker image is a whopping `842 MB`.

`ruby:alpine` is a mere `51.5 MB`, raised to `52.3 MB` with mdl installed.

Neither this action or mdl need anything extra pulled into the docker image to run and has been running without issues for the past week using my fork.

https://github.com/chrislgarry/Apollo-11/actions?query=workflow%3Amarkdownlint

![image](https://user-images.githubusercontent.com/3440094/84179909-92941180-aa7e-11ea-9b6b-58103d0dabe9.png)

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
