### PR TITLE
Replace deprecated set-output command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,10 +16,10 @@ exit_code=$?
 
 echo "$output"
 
-# See https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
+# See https://github.com/community/community/discussions/26288
 output="${output//'%'/'%25'}"
 output="${output//$'\n'/'%0A'}"
 output="${output//$'\r'/'%0D'}"
-echo "::set-output name=output::$output"
+echo "output=$output" >> $GITHUB_OUTPUT
 
 exit $exit_code


### PR DESCRIPTION
# Description

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This updates the action to replace the deprecated `set-output` command.

This will resolve warnings that currently show up when using `markdownlint` like this

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Issues Resolved


## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
